### PR TITLE
Added a pair of examples to extant documentation for quick-reference …

### DIFF
--- a/rest_specification/bulk_request.md
+++ b/rest_specification/bulk_request.md
@@ -29,3 +29,64 @@ Contains a list of requests. Each request has a sequence number that can be used
 ```
 
 Where response is a [response JSON document](https://raw.githubusercontent.com/lightblue-platform/lightblue-core/master/crud/src/main/resources/json-schema/response.json).
+
+### Sample Request:
+This is a sample bulk request that looks for two specific combinations of cheese and sauce choices on a pizza entity.
+```
+{
+    "requests": [
+        {
+            "seq":0,
+            "op": "find",
+            "request": {
+                "entity": "pizza",
+                "entityVersion": "0.1.0",
+                "query": { "$and" : [
+                    {
+                        "field": "cheese",
+                          "op": "=",
+                          "rvalue": "blend"
+                    },
+                    {
+                        "field" : "sauce",
+                        "op" : "=",
+                        "rvalue" : "red"
+                    }
+                    ]
+                },
+                "projection": {
+                    "field": "*",
+                    "recursive": true
+                },
+                "range": [0,10]
+            }
+        },
+        {
+            "seq":1,
+            "op": "find",
+            "request": {
+                "entity": "pizza",
+                "entityVersion": "0.1.0",
+                "query": { "$and" : [
+                    {
+                        "field": "cheese",
+                          "op": "=",
+                          "rvalue": "romano"
+                    },
+                    {
+                        "field" : "sauce",
+                        "op" : "=",
+                        "rvalue" : "garlic"
+                    }
+                    ]
+                },
+                "projection": {
+                    "field": "*",
+                    "recursive": true
+                },
+                "range": [0,10]
+            }
+        }
+    ]
+ }
+```

--- a/rest_specification/put_update_entity_info.md
+++ b/rest_specification/put_update_entity_info.md
@@ -17,3 +17,54 @@ Additional error codes:
 * metadata:NoEntityName - no entity name specified
 * rest-metadata:NoNameMatch - entity name on the path does not match entity name in the json document
 * metadata:MissingEntityInfo - entity info does not exist and therefore cannot be updated
+
+### Sample Request
+This example ensures there's an index on sandwich toppings, and a notification hook that creates events when the toppings field is updated.
+```
+PUT /metadata/sandwich
+{
+    "datastore": {
+        "backend": "mongo",
+        "collection": "sandwich",
+        "datasource": "mongodata"
+    },
+    "defaultVersion": "0.0.66",
+    "indexes": [
+        {
+            "fields": [
+                {
+                    "dir": "$asc",
+                    "field": "sandwichNumber"
+                }
+            ],
+            "name": "sandwich_sandwichNumber",
+            "unique": true
+        },
+    ],
+    "hooks": [
+      {
+        "name": "toppingNotificationHook",
+        "actions": [
+          "insert",
+          "update"
+        ],
+        "configuration": {
+          "watchProjection":[
+            {
+              "field":"_id",
+              "include":true,
+              "recursive":false
+            },
+            {
+              "field":"toppings",
+              "include":true,
+              "recursive":false
+            }
+          ],
+          "includeProjection":[ ],
+          "arrayOrderingSignificant":false
+        }
+    } ],
+    "name": "sandwich"
+}
+```


### PR DESCRIPTION
…purposes.

I tried to sanitize these a bit, but I thought it would be useful to include an example for each of these requests as I found constituting them from the json schema to be a less than productive experience.
